### PR TITLE
Fixed zooming in on the mobile platform

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
         }
 
         #canvas {
-            position: absolute;
             width: 100%;
         }
     </style>

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
                 Try <a href="http://www.google.com/chrome">Chrome</a> or <a href="http://firefox.com">Firefox</a>.</p>
         </canvas>
         <p>This is a real-time fractal zoomer.  Using it is simple: left-click to zoom in, right-click to zoom out.</p>
+        <p>Touch Devices: Use one finger to zoom in, two fingers to zoom out. Interrupt zoom out with one finger.</p>
     </div>
     <div class="modal fade" id="about" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
         <div class="modal-dialog" role="document">

--- a/index.html
+++ b/index.html
@@ -23,8 +23,14 @@
 
 		.container-canvas {
 			margin: 0 auto;
-			width: 1024px;
-		}
+            position: relative;
+            width: 100%;
+        }
+
+        #canvas {
+            position: absolute;
+            width: 100%;
+        }
     </style>
 </head>
 
@@ -53,7 +59,7 @@
 
 <div class="container">
     <div class="container-canvas">
-        <canvas id="canvas" width="1024" height="768">
+        <canvas id="canvas">
             <p>Your browser doesn't seem to support the &lt;canvas&gt; tag.
                 Try <a href="http://www.google.com/chrome">Chrome</a> or <a href="http://firefox.com">Firefox</a>.</p>
         </canvas>

--- a/js/xaos.js
+++ b/js/xaos.js
@@ -1255,7 +1255,34 @@ xaos.zoom = (function() {
             }
         }
 
-        canvas.onmousedown = function(e) {
+        canvas.ontouchstart = function(e) {
+            if(e.touches.length < 3){
+                var touch = e.touches[0];
+                (e.touches.length == 2)?mouse.button[2]=true:mouse.button[2]=false;
+                var mouseEvent = new MouseEvent("mousedown", {
+                    clientX: touch.clientX,
+                    clientY: touch.clientY
+                });
+                canvas.dispatchEvent(mouseEvent);
+            }
+        };
+
+        canvas.ontouchend = function(e) {
+            console.log(e);
+            var mouseEvent = new MouseEvent("mouseup", {});
+            canvas.dispatchEvent(mouseEvent);
+        };
+
+        canvas.ontouchmove = function(e) {
+            var touch = e.touches[0];
+            var mouseEvent = new MouseEvent("mousemove", {
+                clientX: touch.clientX,
+                clientY: touch.clientY
+            });
+            canvas.dispatchEvent(mouseEvent);
+        };
+
+        canvas.onmousedown =  function(e) {
             mouse.button[e.button] = true;
             mouse.x = e.offsetX || (e.clientX - canvas.offsetLeft);
             mouse.y = e.offsetY || (e.clientY - canvas.offsetTop);

--- a/js/xaos.js
+++ b/js/xaos.js
@@ -84,8 +84,8 @@ xaos.zoom = (function() {
     function CanvasImage(canvas) {
 
         if (canvas.width !== innerWidth || canvas.height !== innerHeight) {
-            canvas.width = innerWidth;
-            canvas.height = innerHeight;
+            canvas.width = innerWidth - innerWidth*0.2;
+            canvas.height = innerHeight - innerHeight*0.2;
         } else {
             ctx.clearRect(0, 0, canvas.width, canvas.height);
         }

--- a/js/xaos.js
+++ b/js/xaos.js
@@ -82,6 +82,14 @@ xaos.zoom = (function() {
      * @constructor
      */
     function CanvasImage(canvas) {
+
+        if (canvas.width !== innerWidth || canvas.height !== innerHeight) {
+            canvas.width = innerWidth;
+            canvas.height = innerHeight;
+        } else {
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+        }
+
         this.canvas = canvas;
         this.context = canvas.getContext("2d");
         this.width = canvas.width;


### PR DESCRIPTION
Fixes #5 
This PR addresses two issues:

1. Responsive view of the website
2. Touch zooming capability added for touch devices

Live at https://kanurag94.github.io/XaoSjs/index.html

We can now use one finger to zoom in, two fingers to zoom out and Interrupt zoom out with one finger

Follow Up: Zoom out should stop after fingers are removed. This is faulty since, capturing touch points is difficult. May be we can shift to pinch zoom in/ zoom out.